### PR TITLE
Add unistd.h for __APPLE__

### DIFF
--- a/NodeCoreAudio/AudioEngine.cpp
+++ b/NodeCoreAudio/AudioEngine.cpp
@@ -19,6 +19,10 @@
 	#include <string.h>
 #endif
 
+#ifdef __APPLE__
+	#include <unistd.h>
+#endif
+
 using namespace v8; using namespace std;
 
 Persistent<Function> Audio::AudioEngine::constructor;


### PR DESCRIPTION
Fixes the install on Apple devices where `sleep` was undefined (tested on node v9.4.0 and High Sierra)