### PR TITLE
feat: adapt to node v10 requirements for overloading

### DIFF
--- a/NodeCoreAudio/AudioEngine.cpp
+++ b/NodeCoreAudio/AudioEngine.cpp
@@ -473,11 +473,11 @@ void Audio::AudioEngine::NewInstance(const Nan::FunctionCallbackInfo<v8::Value>&
 	if( argc > 1 )
 		argv[1] = info[1];
 
+ 	v8::Local<v8::Function> cons = Nan::New(constructor);
 	//Local<Object> instance = constructor->NewInstance( argc, argv );
-	Local<Object> instance = Nan::New(constructor)->NewInstance(argc, argv);
 	//Local<Object> instance = constructor->NewInstance(argc, argv);
 
-	info.GetReturnValue().Set( instance );
+	info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
 } // end AudioEngine::NewInstance()
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi,

As node v10 takes over, it seems that some changed are required. 

From what I've managed to understand NaN upgraded the usage of their methods. That's why the application complains about overloading.

This PR is pretty much based of this examples:

https://github.com/nodejs/nan/blob/master/doc/object_wrappers.md#examples