### PR TITLE
docs: fix simple typo, ourput -> output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var engine = coreAudio.createNewAudioEngine();
 
 // Add an audio processing callback
 // This function accepts an input buffer coming from the sound card,
-// and returns an ourput buffer to be sent to your speakers.
+// and returns an output buffer to be sent to your speakers.
 //
 // Note: This function must return an output buffer
 function processAudio( inputBuffer ) {


### PR DESCRIPTION
There is a small typo in README.md.

Should read `output` rather than `ourput`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md